### PR TITLE
TC_14.001.02 | Breadcrumbs > Breadcrumbs drop-down menu > User can navigate to the parent folder configuration page

### DIFF
--- a/src/test/java/school/redrover/BreadcrumbTest.java
+++ b/src/test/java/school/redrover/BreadcrumbTest.java
@@ -9,6 +9,8 @@ import org.testng.annotations.Test;
 import school.redrover.common.BaseTest;
 import school.redrover.common.TestUtils;
 
+import java.util.List;
+
 public class BreadcrumbTest extends BaseTest {
 
     public static final String FOLDER_PARENT = "FolderParent";
@@ -21,19 +23,43 @@ public class BreadcrumbTest extends BaseTest {
                 By.xpath("//a[@href='/view/all/newJob']"))).isDisplayed();
     }
 
-   @Test
-   public void testNavigateToParentFolder() {
-       TestUtils.createJob(getDriver(), getWait10(), FOLDER_PARENT, TestUtils.JobType.FOLDER );
-       goToMainPage();
-       TestUtils.createNestedJob(getDriver(), getWait10(), FOLDER_PARENT, FOLDER_CHILD, TestUtils.JobType.FOLDER );
-       goToMainPage();
+    @Test
+    public void testNavigateToParentFolder() {
+        TestUtils.createJob(getDriver(), getWait10(), FOLDER_PARENT, TestUtils.JobType.FOLDER);
+        goToMainPage();
+        TestUtils.createNestedJob(getDriver(), getWait10(), FOLDER_PARENT, FOLDER_CHILD, TestUtils.JobType.FOLDER);
+        goToMainPage();
 
-       getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//td/a[@href='job/%s/']".formatted(FOLDER_PARENT)))).click();
-       getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//td/a[@href='job/%s/']".formatted(FOLDER_CHILD)))).click();
+        getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//td/a[@href='job/%s/']".formatted(FOLDER_PARENT)))).click();
+        getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//td/a[@href='job/%s/']".formatted(FOLDER_CHILD)))).click();
 
-       getWait10().until(ExpectedConditions.textToBePresentInElementLocated(By.className("job-index-headline"),FOLDER_CHILD));
-       getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//li[@class='jenkins-breadcrumbs__list-item']/a[@href='/job/%s/']".formatted(FOLDER_PARENT)))).click();
+        getWait10().until(ExpectedConditions.textToBePresentInElementLocated(By.className("job-index-headline"), FOLDER_CHILD));
+        getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//li[@class='jenkins-breadcrumbs__list-item']/a[@href='/job/%s/']".formatted(FOLDER_PARENT)))).click();
 
-       Assert.assertEquals(getWait10().until(ExpectedConditions.visibilityOfElementLocated(By.className("job-index-headline"))).getText(), FOLDER_PARENT);
-   }
+        Assert.assertEquals(getWait10().until(ExpectedConditions.visibilityOfElementLocated(By.className("job-index-headline"))).getText(), FOLDER_PARENT);
+    }
+
+    @Test(dependsOnMethods = "testNavigateToParentFolder")
+    public void testNavigateToParentConfigPage() {
+        getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//td/a[@href='job/%s/']".formatted(FOLDER_PARENT)))).click();
+        getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//td/a[@href='job/%s/']".formatted(FOLDER_CHILD)))).click();
+        getWait10().until(ExpectedConditions.textToBePresentInElementLocated(By.className("job-index-headline"), FOLDER_CHILD));
+
+        getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//a[contains(@href, '/job/%s/')]/following-sibling::div[@class='dropdown-indicator']".formatted(FOLDER_PARENT)))).click();
+        getWait10().until(ExpectedConditions.elementToBeClickable(By.xpath("//a[@class='jenkins-dropdown__item ' and contains(@href, '/job/%s/configure')]".formatted(FOLDER_PARENT)))).click();
+
+        getWait10().until(ExpectedConditions.textToBePresentInElementLocated(By.xpath("//h1"), "Configuration"));
+
+        List<String> actualBreadcrumbs = getWait10()
+                .until(ExpectedConditions.presenceOfAllElementsLocatedBy(By.cssSelector("#breadcrumbs .jenkins-breadcrumbs__list-item")))
+                .stream()
+                .map(WebElement::getText)
+                .map(String::trim)
+                .filter(text -> !text.isEmpty())
+                .toList();
+
+        Assert.assertEquals(actualBreadcrumbs, List.of(FOLDER_PARENT, "Configuration"), "Breadcrumbs sequence is wrong!");
+
+    }
 }
+


### PR DESCRIPTION
https://github.com/RedRoverSchool/JenkinsQA_Java_2026_spring/issues/729