### PR TITLE
Remove Allure listener and dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,5 @@
             <version>6.0.0</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>io.qameta.allure</groupId>
-            <artifactId>allure-testng</artifactId>
-            <version>2.34.0</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/school/redrover/common/BaseTest.java
+++ b/src/test/java/school/redrover/common/BaseTest.java
@@ -1,7 +1,5 @@
 package school.redrover.common;
 
-import org.openqa.selenium.OutputType;
-import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.ITestResult;
@@ -10,16 +8,12 @@ import school.redrover.common.filter.FilterForTests;
 import school.redrover.common.order.OrderForTests;
 import school.redrover.common.order.OrderUtils;
 
-import java.io.File;
 import java.lang.reflect.Method;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import io.qameta.allure.testng.AllureTestNg;
-import org.testng.annotations.Listeners;
 
-@Listeners({FilterForTests.class, OrderForTests.class, AllureTestNg.class})
+@Listeners({FilterForTests.class, OrderForTests.class})
 public abstract class BaseTest {
 
     private WebDriver driver;


### PR DESCRIPTION
Removes AllureTestNg listener from BaseTest and allure-testng dependency from pom.xml because CI is failing after Allure integration.