### PR TITLE
Fix node usage dropdown click

### DIFF
--- a/src/test/java/school/redrover/page/manage/NodeConfigPage.java
+++ b/src/test/java/school/redrover/page/manage/NodeConfigPage.java
@@ -1,10 +1,15 @@
 package school.redrover.page.manage;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import school.redrover.page.common.BasePage;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,10 +35,21 @@ public class NodeConfigPage extends BasePage {
     }
 
     public NodeConfigPage changeUsage(String usage) {
-        getDriver().findElement(By.xpath("//select[@name='mode']")).click();
-        getDriver().findElement(By.xpath("//option[@value='%s']".formatted(usage))).click();
-        return this;
-    }
+
+            WebElement usageSelect = getDriver().findElement(By.xpath("//select[@name='mode']"));
+
+            ((JavascriptExecutor) getDriver()).executeScript(
+                    "arguments[0].scrollIntoView({block: 'center', inline: 'nearest'});",
+                    usageSelect
+            );
+
+            new WebDriverWait(getDriver(), Duration.ofSeconds(5))
+                    .until(ExpectedConditions.elementToBeClickable(usageSelect));
+
+            new Select(usageSelect).selectByValue(usage);
+
+            return this;
+        }
 
     public NodeConfigPage saveChanges() {
         getDriver().findElement(By.xpath("//button[@value='Save']")).click();

--- a/src/test/java/school/redrover/page/manage/NodeConfigPage.java
+++ b/src/test/java/school/redrover/page/manage/NodeConfigPage.java
@@ -6,10 +6,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
-import org.openqa.selenium.support.ui.WebDriverWait;
 import school.redrover.page.common.BasePage;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,8 +41,7 @@ public class NodeConfigPage extends BasePage {
                     usageSelect
             );
 
-            new WebDriverWait(getDriver(), Duration.ofSeconds(5))
-                    .until(ExpectedConditions.elementToBeClickable(usageSelect));
+            getWait5().until(ExpectedConditions.elementToBeClickable(usageSelect));
 
             new Select(usageSelect).selectByValue(usage);
 


### PR DESCRIPTION
### Summary

Fixed `NodeTest.testNodeConfiguration` failure caused by `ElementClickInterceptedException`.

The `Usage` dropdown on the node configuration page could be overlapped by the Jenkins bottom sticky button panel, so Selenium was unable to click the `<select name="mode">` element.

### Changes

* Updated `NodeConfigPage.changeUsage()`
* Added scroll to the `Usage` dropdown before selecting a value
* Replaced direct click on `<select>` and `<option>` with Selenium `Select`
* Added explicit wait until the dropdown is clickable

### Test result

Checked locally: `NodeTest` passes after the fix.
