### PR TITLE
Enable view within folder description tests

### DIFF
--- a/src/test/java/school/redrover/ViewWithinFolderTest.java
+++ b/src/test/java/school/redrover/ViewWithinFolderTest.java
@@ -1,12 +1,10 @@
 package school.redrover;
 
 import org.testng.Assert;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 import school.redrover.common.BaseTest;
 import school.redrover.page.HomePage;
 import school.redrover.page.project.FolderProjectPage;
-import school.redrover.page.project.config.FolderConfigPage;
 
 public class ViewWithinFolderTest extends BaseTest {
 
@@ -42,7 +40,6 @@ public class ViewWithinFolderTest extends BaseTest {
         Assert.assertEquals(actualPreviewText, VIEW_DESCRIPTION);
     }
 
-    @Ignore
     @Test(dependsOnMethods = "testPreviewAddDescription")
     public void testSaveViewDescription() {
        String actualDescriptionText = new HomePage(getDriver())
@@ -54,8 +51,7 @@ public class ViewWithinFolderTest extends BaseTest {
 
         Assert.assertEquals(actualDescriptionText, VIEW_DESCRIPTION);
     }
-  
-    @Ignore
+
     @Test(dependsOnMethods = "testSaveViewDescription")
     public void testCancelDescription() {
         String actualDescriptionTest = new HomePage(getDriver())


### PR DESCRIPTION
### Summary

Removed obsolete `@Ignore` annotations from `ViewWithinFolderTest`.

The ignored tests were rechecked locally and both description-related tests now pass:

* `testSaveViewDescription`
* `testCancelDescription`

These tests were previously disabled in commit `dc58fda4` with the message `ignoring tests`, but after checking the current state of the project they no longer fail.

### Changes

* Enabled `testSaveViewDescription`
* Enabled `testCancelDescription`
* Removed unused imports from `ViewWithinFolderTest`

### Test result

Checked locally:

* `ViewWithinFolderTest` passes successfully
* Full Maven test run includes these tests and they do not fail

Full Maven result:

```text
Tests run: 153, Failures: 2, Errors: 0, Skipped: 2
```

The remaining failures are unrelated to this change:

```text
SignInTest.testSignInPageAlertTextColor
ToolsTest.testAddJDK
```

This PR does not change test logic, Page Objects, or assertions. It only returns already existing passing tests back into the active test suite.
