### PR TITLE
Add test for skipping freestyle project configuration

### DIFF
--- a/src/test/java/school/redrover/FreestyleProjectTest.java
+++ b/src/test/java/school/redrover/FreestyleProjectTest.java
@@ -383,4 +383,17 @@ public class FreestyleProjectTest extends BaseTest {
         softAssert.assertEquals(freestyleProjectPage.getRepositoryUrl(), REPOSITORY_URL, "Repository url is not correct");
         softAssert.assertAll();
     }
+
+    @Test
+    public void testSkipConfigShowsItemOnDashboard() {
+        List<String> actualProjectList = new HomePage(getDriver())
+                .clickItemNewJob()
+                .setProjectName(PROJECT_NAME)
+                .selectFreestyleProjectAndClickOk()
+                .goHomePage()
+                .getProjectList();
+
+        Assert.assertTrue(actualProjectList.contains(PROJECT_NAME),
+                "Created item is not displayed on the dashboard");
+    }
 }


### PR DESCRIPTION
Verify that a user can create a Freestyle project, skip the configuration page by clicking the Jenkins icon, and see the created item on the Jenkins dashboard.
